### PR TITLE
Fix Mac/Linux instructions for importing client profiles

### DIFF
--- a/docs/openvpn.md
+++ b/docs/openvpn.md
@@ -66,7 +66,9 @@ Use a program like WinSCP or Cyberduck. Note that you may need administrator per
 
 ### Mac/Linux
 
-Open the Terminal app and copy the config from the Raspberry Pi using`scp pi-user@ip-of-your-raspberry:ovpns/whatever.ovpn`. The file will be downloaded in the current working directory, which usually is the home folder of your PC.
+Open the Terminal app and copy the config from the Raspberry Pi to a target directory on your local machine:
+
+`scp pi-user@ip-of-your-raspberry:ovpns/whatever.ovpn path/to/target`.
 
 ### Android
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -35,3 +35,4 @@ A secure docker container that sets up PiVPN and SSH.
 The foundation for all open-source VPN projects.
 * [WireGuard](https://www.wireguard.com/)
 *An extremely simple yet fast and modern VPN that utilizes state-of-the-art cryptography.*
+* [PiVPN Web](https://github.com/WeeJeWel/pivpn-web) A web-based management UI for PiVPN WireGuard installations.

--- a/docs/wireguard.md
+++ b/docs/wireguard.md
@@ -61,7 +61,9 @@ Use a program like WinSCP or Cyberduck. Note that you may need administrator per
 
 ### Mac/Linux
 
-Open the Terminal app and copy the config from the Raspberry Pi using `scp pi-user@ip-of-your-raspberry:configs/whatever.conf`. The file will be downloaded in the current working directory, which usually is the home folder of your PC.
+Open the Terminal app and copy the config from the Raspberry Pi to a target directory on your local machine:
+
+`scp pi-user@ip-of-your-raspberry:configs/whatever.conf path/to/target`.
 
 ### Android / iOS
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,6 @@ theme:
   palette:
     primary: blue grey
   features:
-    - navigation.sections
     - navigation.expand
 
 repo_name: PiVPN


### PR DESCRIPTION
This PR fixes an issue I observed with the Mac/Linux instructions on the OpenVPN and Wireguard pages. Specifically, it fixes the `scp` command to add a reference to a target directory, which is required as per the [scp man page](https://linux.die.net/man/1/scp).