### PR TITLE
Remove deprecated pivpn-web project

### DIFF
--- a/docs/projects.md
+++ b/docs/projects.md
@@ -29,4 +29,3 @@ A secure docker container that sets up PiVPN and SSH.
 The foundation for all open-source VPN projects.
 * [WireGuard](https://www.wireguard.com/)
 *An extremely simple yet fast and modern VPN that utilizes state-of-the-art cryptography.*
-* [PiVPN Web](https://github.com/WeeJeWel/pivpn-web) A web-based management UI for PiVPN WireGuard installations.


### PR DESCRIPTION
https://github.com/WeeJeWel/pivpn-web has a archive notice, as well as a link directing users to remove this project and use the authors personal project.