### PR TITLE
Corrected Alpine Linux requirements section

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -85,6 +85,8 @@ pivpnGitBranch="myfeaturebranch"
 * run as root or have sudo installed 
     * `apk add sudo; echo '%wheel ALL=(ALL) ALL' > /etc/sudoers.d/wheel`
 
+Enable the community [repository](https://wiki.alpinelinux.org/wiki/Repositories)
+
 #### AWS Cloud Images (AMI)
 
 On AWS sudo is is not available by default in the the Alpine AMI'and you should use `doas` to install the required dependencies. 

--- a/docs/install.md
+++ b/docs/install.md
@@ -77,8 +77,11 @@ pivpnGitBranch="myfeaturebranch"
 
 * Bash 
     * `apk add bash`
-* busybox-initscripts 
-    * `apk add busybox-initscripts`
+* busybox openrc initscripts
+    * v3.16 or earlier
+        * `apk add busybox-initscripts`
+    * v3.17+
+        * `apk add busybox-openrc`
 * run as root or have sudo installed 
     * `apk add sudo; echo '%wheel ALL=(ALL) ALL' > /etc/sudoers.d/wheel`
 


### PR DESCRIPTION
The mentioned package `busybox-initscripts` has been renamed in the Alpine repos. So I made a note of that, as well as that the community repository is required for the install.