### PR TITLE
Remove EOL OSes and added latest LTS

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -7,20 +7,19 @@ summary: Frequently asked questions
 
 ### PiVPN runs at least on the following hardware
 
-* Raspberry Pi models (1/2/3/4/Zero) 
+* Raspberry Pi models (1/2/3/4/5/Zero) 
 * All SBC's supported by [DietPi](https://dietpi.com/).
 * x86_64 (Intel and AMD) servers 
 
 ### PiVPN Supports the following systems
 
   * Raspbian and Raspberry PI OS
-    * Stretch
-    * Buster
     * Bullseye
+    * Bookworm
   * Ubuntu Server
-    * Bionic Beaver (18.04)
     * Focal Fossa (20.04)
     * Jammy Jellyfish (22.04)
+    * Noble Numbat (24.04)
   * [DietPi](https://dietpi.com/)
   * [Alpine Linux](install.md#alpine)
 


### PR DESCRIPTION
removed the following
https://wiki.debian.org/LTS
- Debian 9 “Stretch” - June 30, 2022
- Debian 10 “Buster” - June 30th, 2024 

https://ubuntu.com/about/release-cycle
- Bionic Beaver (18.04) - May 2023


Added the following
- Bookworm (Debian 12)
- Noble Numbat (24.04)